### PR TITLE
FileStore.Adapters.S3.stat/2 ignores configuration

### DIFF
--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -66,7 +66,7 @@ if Code.ensure_compiled?(ExAws.S3) do
       store
       |> get_bucket()
       |> ExAws.S3.head_object(key)
-      |> ExAws.request()
+      |> request(store)
       |> case do
         {:ok, %{headers: headers}} ->
           headers = Enum.into(headers, %{})


### PR DESCRIPTION
- Change FileStore.Adapters.S3.stat/2 to call the private request/2 function that correctly provides ExAws.S3 configuration overrides to the operation.