### PR TITLE
read/1 is missing with use FileStore.Config

### DIFF
--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -55,6 +55,11 @@ defmodule FileStore.Config do
         FileStore.stat(new(), key)
       end
 
+      @spec read(binary()) :: {:ok, iodata} | {:error, term}
+      def read(key) do
+        FileStore.read(new(), key)
+      end
+
       @spec write(binary(), iodata()) :: :ok | {:error, term()}
       def write(key, content) do
         FileStore.write(new(), key, content)


### PR DESCRIPTION
- Add a wrapper implementation for read/1 in the __using__/1 macro.