### PR TITLE
Add a delete operation to FileStore.Adapter

### DIFF
--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -120,6 +120,21 @@ defmodule FileStore do
   end
 
   @doc """
+  Delete a file from the store.
+
+  ## Examples
+
+    iex> FileStore.delete(store, "foo")
+    :ok
+
+  """
+  @impl true
+  @spec delete(t, key) :: :ok | {:error, term}
+  def delete(store, key) do
+    store.adapter.delete(store, key)
+  end
+
+  @doc """
   Get URL for your file, assuming that the file is publicly accessible.
 
   ## Examples

--- a/lib/file_store/adapter.ex
+++ b/lib/file_store/adapter.ex
@@ -11,6 +11,7 @@ defmodule FileStore.Adapter do
   @callback upload(store, Path.t(), key) :: :ok | {:error, term}
   @callback download(store, key, Path.t()) :: :ok | {:error, term}
   @callback stat(store, key) :: {:ok, Stat.t()} | {:error, term}
+  @callback delete(store, key) :: :ok | {:error, term}
   @callback get_public_url(store, key) :: binary
   @callback get_public_url(store, key, keyword) :: binary
   @callback get_signed_url(store, key, keyword) :: {:ok, binary} | {:error, term}

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -58,7 +58,7 @@ defmodule FileStore.Adapters.Disk do
 
   @impl true
   def delete(store, key) do
-    File.r(join(store, key))
+    File.rm(join(store, key))
   end
 
   @impl true

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -57,6 +57,11 @@ defmodule FileStore.Adapters.Disk do
   end
 
   @impl true
+  def delete(store, key) do
+    File.r(join(store, key))
+  end
+
+  @impl true
   def write(store, key, content) do
     with {:ok, path} <- expand(store, key) do
       File.write(path, content)

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -85,6 +85,13 @@ defmodule FileStore.Adapters.Memory do
   end
 
   @impl true
+  def delete(store, key) do
+    store
+    |> get_name()
+    |> Agent.update(&Map.delete(&1, key))
+  end
+
+  @impl true
   def write(store, key, content) do
     store
     |> get_name()

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -29,6 +29,9 @@ defmodule FileStore.Adapters.Null do
   def stat(_store, key), do: {:ok, %Stat{key: key, size: 0, etag: Stat.checksum("")}}
 
   @impl true
+  def delete(_store, _key), do: :ok
+
+  @impl true
   def upload(_store, _source, _key), do: :ok
 
   @impl true

--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -87,6 +87,14 @@ if Code.ensure_loaded?(ExAws.S3) do
     end
 
     @impl true
+    def delete(store, key) do
+      store
+      |> get_bucket()
+      |> ExAws.S3.delete_object(key)
+      |> acknowledge(store)
+    end
+
+    @impl true
     def write(store, key, content) do
       store
       |> get_bucket()

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -65,6 +65,11 @@ defmodule FileStore.Config do
         FileStore.write(new(), key, content)
       end
 
+      @spec delete(binary()) :: :ok | {:error, term()}
+      def delete(key) do
+        FileStore.delete(new(), key)
+      end
+
       @spec upload(Path.t(), binary()) :: :ok | {:error, term()}
       def upload(source, key) do
         FileStore.upload(new(), source, key)

--- a/test/file_store_test.exs
+++ b/test/file_store_test.exs
@@ -20,6 +20,10 @@ defmodule FileStoreTest do
     assert FileStore.get_signed_url(@store, @key) == {:ok, @key}
   end
 
+  test "delete/2" do
+    assert FileStore.delete(@store, @key) == :ok
+  end
+
   test "upload/3" do
     assert :ok = FileStore.upload(@store, @path, @key)
   end

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -76,6 +76,13 @@ defmodule FileStore.AdapterCase do
         end
       end
 
+      describe "delete/2" do
+        test "deletes the file", %{store: store} do
+          assert :ok = FileStore.write(store, "foo", "bar")
+          assert :ok = FileStore.delete(store, "foo")
+        end
+      end
+
       describe "get_public_url/2" do
         test "returns a URL", %{store: store} do
           assert :ok = FileStore.write(store, "foo", "bar")


### PR DESCRIPTION
Added `FileStore.delete/2`. Note that the the Memory can’t return `{:error, _}`, and the S3 _won’t_ return `{:error, :enoent}` for a missing object (it returns 204), so there’s no test added for `FileStore.delete/2` failure in `AdapterCase`. We could viably test this in `disk_test.exs`, but I’m not too worried about it, personally (I’m mostly using this for the S3 adapter).