### PR TITLE
Fix an error in FileStore.Adapters.S3.write/3

### DIFF
--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -83,7 +83,7 @@ if Code.ensure_compiled?(ExAws.S3) do
     def write(store, key, content) do
       store
       |> get_bucket()
-      |> ExAws.S3.put_object(key, content)
+      |> ExAws.S3.put_object(key, IO.iodata_to_binary(content))
       |> acknowledge(store)
     end
 


### PR DESCRIPTION
The callback specification for FileStore.Adapter.write/3 is:

```elixir
  @callback write(store, key, iodata) :: :ok | {:error, term}
```

However, ExAws.S3.put_object/2 _only_ supports _binary_. To ensure that this
doesn't break, call IO.iodata_to_binary(content) immediately on calling
ExAws.S3.put_object/2 in FileStore.Adapters.S3.write/3.