### PR TITLE
Clarify that `write/3` only accepts binary data

### DIFF
--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -53,7 +53,7 @@ defmodule FileStore do
 
   """
   @impl true
-  @spec write(t, key, iodata) :: :ok | {:error, term}
+  @spec write(t, key, binary) :: :ok | {:error, term}
   def write(store, key, content) do
     store.adapter.write(store, key, content)
   end
@@ -68,7 +68,7 @@ defmodule FileStore do
 
   """
   @impl true
-  @spec read(t, key) :: {:ok, iodata} | {:error, term}
+  @spec read(t, key) :: {:ok, binary} | {:error, term}
   def read(store, key) do
     store.adapter.read(store, key)
   end

--- a/lib/file_store/adapter.ex
+++ b/lib/file_store/adapter.ex
@@ -6,8 +6,8 @@ defmodule FileStore.Adapter do
   @type store :: FileStore.t()
   @type key :: FileStore.key()
 
-  @callback write(store, key, iodata) :: :ok | {:error, term}
-  @callback read(store, key) :: {:ok, iodata} | {:error, term}
+  @callback write(store, key, binary) :: :ok | {:error, term}
+  @callback read(store, key) :: {:ok, binary} | {:error, term}
   @callback upload(store, Path.t(), key) :: :ok | {:error, term}
   @callback download(store, key, Path.t()) :: :ok | {:error, term}
   @callback stat(store, key) :: {:ok, Stat.t()} | {:error, term}

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -55,12 +55,12 @@ defmodule FileStore.Config do
         FileStore.stat(new(), key)
       end
 
-      @spec read(binary()) :: {:ok, iodata} | {:error, term}
+      @spec read(binary()) :: {:ok, binary()} | {:error, term()}
       def read(key) do
         FileStore.read(new(), key)
       end
 
-      @spec write(binary(), iodata()) :: :ok | {:error, term()}
+      @spec write(binary(), binary()) :: :ok | {:error, term()}
       def write(key, content) do
         FileStore.write(new(), key, content)
       end


### PR DESCRIPTION
In #6, @halostatue pointed out that the declaration of `write/3` said that it accepted any iodata. The recommended solution was to call `IO.iodata_to_binary/1` on the incoming content.

I tried to write a test for this behavior, but the test ended up looking like this:

```elixir
:ok = FileStore.write(store, "foo", [?b, "a", ["r"]])
{:ok, "bar"} = FileStore.read(store, "foo")
```

That test passes for the disk and S3 adapters, but fails for the memory adapter, so we'd have to also convert to binary there as well.

I don't love that you put in iodata, but get out a binary. Instead, I think it is simpler to just say that `write/3` and `read/2` only operate on binary data. People using this library can simply call `IO.iodata_to_binary/1` before calling write.

```elixir
:ok = FileStore.write(store, "foo",  IO.iodata_to_binary([?b, "a", ["r"]]))
{:ok, "bar"} = FileStore.read(store, "foo")
```

Closes #6 

