### PR TITLE
Add the ability to list files in the store

### DIFF
--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -164,4 +164,13 @@ defmodule FileStore do
   def get_signed_url(store, key, opts \\ []) do
     store.adapter.get_signed_url(store, key, opts)
   end
+
+  @doc """
+  List all of the files in the store.
+  """
+  @impl true
+  @spec list(t) :: Enumerable.t()
+  def list(store) do
+    store.adapter.list(store)
+  end
 end

--- a/lib/file_store/adapter.ex
+++ b/lib/file_store/adapter.ex
@@ -15,4 +15,5 @@ defmodule FileStore.Adapter do
   @callback get_public_url(store, key) :: binary
   @callback get_public_url(store, key, keyword) :: binary
   @callback get_signed_url(store, key, keyword) :: {:ok, binary} | {:error, term}
+  @callback list(store) :: Enumerable.t()
 end

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -87,6 +87,17 @@ defmodule FileStore.Adapters.Disk do
          do: :ok
   end
 
+  @impl true
+  def list(store) do
+    path = get_storage_path(store)
+
+    path
+    |> Path.join("**/*")
+    |> Path.wildcard(match_dot: true)
+    |> Stream.reject(&File.dir?/1)
+    |> Stream.map(&Path.relative_to(&1, path))
+  end
+
   defp expand(store, key) do
     with path <- join(store, key),
          dir <- Path.dirname(path),

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -120,6 +120,14 @@ defmodule FileStore.Adapters.Memory do
     end
   end
 
+  @impl true
+  def list(store) do
+    store
+    |> get_name()
+    |> Agent.get(&Map.keys/1)
+    |> Stream.into([])
+  end
+
   defp get_name(store) do
     Map.get(store.config, :name, __MODULE__)
   end

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -42,4 +42,7 @@ defmodule FileStore.Adapters.Null do
 
   @impl true
   def read(_store, _key), do: {:ok, ""}
+
+  @impl true
+  def list(_store), do: Stream.into([], [])
 end

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -89,6 +89,11 @@ defmodule FileStore.Config do
       def get_signed_url(key, opts \\ []) do
         FileStore.get_signed_url(new(), key, opts)
       end
+
+      @spec list() :: Enumerable.t()
+      def list() do
+        FileStore.list(new())
+      end
     end
   end
 end

--- a/test/file_store/adapters/null_test.exs
+++ b/test/file_store/adapters/null_test.exs
@@ -39,4 +39,8 @@ defmodule FileStore.Adapters.NullTest do
     assert stat.size == 0
     assert stat.etag == "d41d8cd98f00b204e9800998ecf8427e"
   end
+
+  test "list/0", %{store: store} do
+    assert Enum.to_list(FileStore.list(store)) == []
+  end
 end

--- a/test/file_store/adapters/s3_test.exs
+++ b/test/file_store/adapters/s3_test.exs
@@ -4,9 +4,9 @@ defmodule FileStore.Adapters.S3Test do
 
   @region "us-east-1"
   @bucket "filestore"
-  @prefix "images"
+  @prefix "prefix"
   @url "https://filestore.s3-us-east-1.amazonaws.com/foo"
-  @prefixed_url "https://filestore.s3-us-east-1.amazonaws.com/images/foo"
+  @prefixed_url "https://filestore.s3-us-east-1.amazonaws.com/prefix/foo"
 
   setup do
     {:ok, _} = Application.ensure_all_started(:hackney)
@@ -41,14 +41,19 @@ defmodule FileStore.Adapters.S3Test do
 
     test "get_signed_url/2", %{store: store} do
       assert {:ok, url} = FileStore.get_signed_url(store, "foo")
-      assert get_path(url) == "/filestore/images/foo"
+      assert get_path(url) == "/filestore/prefix/foo"
       assert get_query(url, "X-Amz-Expires") == "3600"
     end
 
     test "get_signed_url/2 with custom expiration", %{store: store} do
       assert {:ok, url} = FileStore.get_signed_url(store, "foo", expires_in: 4000)
-      assert get_path(url) == "/filestore/images/foo"
+      assert get_path(url) == "/filestore/prefix/foo"
       assert get_query(url, "X-Amz-Expires") == "4000"
+    end
+
+    test "list/1 with a custom prefix", %{store: store} do
+      assert :ok = FileStore.write(store, "foo", "")
+      assert "prefix/foo" in Enum.to_list(FileStore.list(store))
     end
   end
 

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -98,6 +98,18 @@ defmodule FileStore.AdapterCase do
           assert is_valid_url(url)
         end
       end
+
+      describe "list/3" do
+        test "lists keys in the store", %{store: store} do
+          assert :ok = FileStore.write(store, "foo", "")
+          assert "foo" in Enum.to_list(FileStore.list(store))
+        end
+
+        test "lists nested keys in the store", %{store: store} do
+          assert :ok = FileStore.write(store, "foo/bar", "")
+          assert "foo/bar" in Enum.to_list(FileStore.list(store))
+        end
+      end
     end
   end
 


### PR DESCRIPTION
By always returning a stream, we can abstract things like pagination away from the user.

For the disk adapter, `Path.wildcard/2` is used, which returns a List after deeply traversing the filesystem. We could take better advantage of streaming by emitting each directory's entries during each level of traversal. This is probably good enough for a first pass, though.

```elixir
store
|> FileStore.list()
|> Stream.each(key ->
  {:ok, stat} = FileStore.stat(store, key)
  IO.puts("#{key}: #{stat.size}")
end)
```

Closes #4 