### PR TITLE
Add the ability to list keys that start with a given prefix

### DIFF
--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -166,17 +166,24 @@ defmodule FileStore do
   end
 
   @doc """
-  List all of the files in the store.
+  List files in the store.
+
+  ## Options
+
+    * `:prefix` - Only return keys matching the given prefix.
 
   ## Examples
 
       iex> Enum.to_list(FileStore.list!(store))
+      ["bar", "foo/bar"]
+
+      iex> Enum.to_list(FileStore.list!(store, prefix: "foo"))
       ["foo/bar"]
 
   """
   @impl true
   @spec list!(t) :: Enumerable.t()
-  def list!(store) do
-    store.adapter.list!(store)
+  def list!(store, opts \\ []) do
+    store.adapter.list!(store, opts)
   end
 end

--- a/lib/file_store/adapter.ex
+++ b/lib/file_store/adapter.ex
@@ -5,6 +5,7 @@ defmodule FileStore.Adapter do
 
   @type store :: FileStore.t()
   @type key :: FileStore.key()
+  @type list_options :: [prefix: binary]
 
   @callback write(store, key, binary) :: :ok | {:error, term}
   @callback read(store, key) :: {:ok, binary} | {:error, term}
@@ -15,5 +16,5 @@ defmodule FileStore.Adapter do
   @callback get_public_url(store, key) :: binary
   @callback get_public_url(store, key, keyword) :: binary
   @callback get_signed_url(store, key, keyword) :: {:ok, binary} | {:error, term}
-  @callback list!(store) :: Enumerable.t()
+  @callback list!(store, list_options) :: Enumerable.t()
 end

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -92,10 +92,12 @@ defmodule FileStore.Adapters.Disk do
   end
 
   @impl true
-  def list!(store) do
+  def list!(store, opts \\ []) do
     path = get_storage_path(store)
+    prefix = Keyword.get(opts, :prefix, "")
 
     path
+    |> Path.join(prefix)
     |> Path.join("**/*")
     |> Path.wildcard(match_dot: true)
     |> Stream.reject(&File.dir?/1)

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -121,11 +121,13 @@ defmodule FileStore.Adapters.Memory do
   end
 
   @impl true
-  def list!(store) do
+  def list!(store, opts \\ []) do
+    prefix = Keyword.get(opts, :prefix, "")
+
     store
     |> get_name()
     |> Agent.get(&Map.keys/1)
-    |> Stream.into([])
+    |> Stream.filter(&String.starts_with?(&1, prefix))
   end
 
   defp get_name(store) do

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -44,5 +44,5 @@ defmodule FileStore.Adapters.Null do
   def read(_store, _key), do: {:ok, ""}
 
   @impl true
-  def list!(_store), do: Stream.into([], [])
+  def list!(_store, _opts \\ []), do: Stream.into([], [])
 end

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -91,8 +91,8 @@ defmodule FileStore.Config do
       end
 
       @spec list! :: Enumerable.t()
-      def list! do
-        FileStore.list!(new())
+      def list!(opts \\ []) do
+        FileStore.list!(new(), opts)
       end
     end
   end

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -104,7 +104,7 @@ defmodule FileStore.AdapterCase do
         end
       end
 
-      describe "list/3" do
+      describe "list/2" do
         test "lists keys in the store", %{store: store} do
           assert :ok = FileStore.write(store, "foo", "")
           assert "foo" in Enum.to_list(FileStore.list!(store))
@@ -113,6 +113,15 @@ defmodule FileStore.AdapterCase do
         test "lists nested keys in the store", %{store: store} do
           assert :ok = FileStore.write(store, "foo/bar", "")
           assert "foo/bar" in Enum.to_list(FileStore.list!(store))
+        end
+
+        test "lists keys matching prefix", %{store: store} do
+          assert :ok = FileStore.write(store, "bar", "")
+          assert :ok = FileStore.write(store, "foo/bar", "")
+
+          keys = Enum.to_list(FileStore.list!(store, prefix: "foo"))
+          refute "bar" in keys
+          assert "foo/bar" in keys
         end
       end
     end


### PR DESCRIPTION
```elixir
iex> Enum.to_list(FileStore.list!(store))
["bar", "foo/bar"]

iex> Enum.to_list(FileStore.list!(store, prefix: "foo"))
["foo/bar"]
```