### PR TITLE
Better joining of URL paths

### DIFF
--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -30,6 +30,7 @@ defmodule FileStore.Adapters.Disk do
   @behaviour FileStore.Adapter
 
   alias FileStore.Stat
+  alias FileStore.Utils
 
   @doc "Get an the path for a given key."
   @spec join(FileStore.t(), binary) :: Path.t()
@@ -39,7 +40,11 @@ defmodule FileStore.Adapters.Disk do
 
   @impl true
   def get_public_url(store, key, _opts \\ []) do
-    store |> get_base_url() |> URI.merge(key) |> URI.to_string()
+    store
+    |> get_base_url()
+    |> URI.parse()
+    |> Utils.append_path(key)
+    |> URI.to_string()
   end
 
   @impl true

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -48,6 +48,7 @@ defmodule FileStore.Adapters.Memory do
   use Agent
 
   alias FileStore.Stat
+  alias FileStore.Utils
 
   @doc "Starts an agent for the test adapter."
   def start_link(opts) do
@@ -62,7 +63,11 @@ defmodule FileStore.Adapters.Memory do
 
   @impl true
   def get_public_url(store, key, _opts \\ []) do
-    store |> get_base_url() |> URI.merge(key) |> URI.to_string()
+    store
+    |> get_base_url()
+    |> URI.parse()
+    |> Utils.append_path(key)
+    |> URI.to_string()
   end
 
   @impl true

--- a/lib/file_store/utils.ex
+++ b/lib/file_store/utils.ex
@@ -1,9 +1,21 @@
 defmodule FileStore.Utils do
   @moduledoc false
 
+  def join(nil, nil), do: nil
   def join(a, nil), do: a
-  def join(a, ""), do: a
   def join(nil, b), do: b
-  def join("", b), do: b
-  def join(a, b), do: String.trim_trailing(a, "/") <> "/" <> b
+
+  def join(a, b) do
+    String.trim_trailing(a, "/") <> "/" <> String.trim_leading(b, "/")
+  end
+
+  def join_absolute(a, b) do
+    if path = join(a, b) do
+      "/" <> String.trim_leading(path, "/")
+    end
+  end
+
+  def append_path(%URI{path: a} = uri, b) do
+    %URI{uri | path: join_absolute(a, b)}
+  end
 end

--- a/test/file_store/utils_test.exs
+++ b/test/file_store/utils_test.exs
@@ -9,8 +9,33 @@ defmodule FileStore.UtilsTest do
     assert Utils.join("a/", "b") == "a/b"
     assert Utils.join("a/", "b/") == "a/b/"
     assert Utils.join("a", nil) == "a"
-    assert Utils.join("a", "") == "a"
     assert Utils.join(nil, "b") == "b"
-    assert Utils.join("", "b") == "b"
+    assert Utils.join(nil, nil) == nil
+  end
+
+  test "join_absolute/2" do
+    assert Utils.join_absolute("a", "b") == "/a/b"
+    assert Utils.join_absolute("a", "b/") == "/a/b/"
+    assert Utils.join_absolute("/a", "/b/") == "/a/b/"
+    assert Utils.join_absolute(nil, "b") == "/b"
+    assert Utils.join_absolute("a", nil) == "/a"
+    assert Utils.join_absolute(nil, nil) == nil
+  end
+
+  test "append_path/2" do
+    assert %URI{path: "/bar"} =
+             "http://example.com"
+             |> URI.parse()
+             |> Utils.append_path("bar")
+
+    assert %URI{path: "/foo/bar"} =
+             "http://example.com/foo"
+             |> URI.parse()
+             |> Utils.append_path("bar")
+
+    assert %URI{path: "/foo/bar"} =
+             "http://example.com/foo/"
+             |> URI.parse()
+             |> Utils.append_path("/bar")
   end
 end


### PR DESCRIPTION
Avoid `URI.merge/2` for appending path segments to URLs. It doesn't always have the desired effect.

For example, if a user configured `base_url: "http://example.com/foo"`:
```elixir
"http://example.com/foo"
|> URI.merge("bar")
|> URI.to_string
# "http://example.com/bar"
```