### PR TITLE
Build a logger middleware

### DIFF
--- a/lib/file_store/middleware/logger.ex
+++ b/lib/file_store/middleware/logger.ex
@@ -1,0 +1,88 @@
+defmodule FileStore.Middleware.Logger do
+  @enforce_keys [:__next__]
+  defstruct [:__next__]
+
+  def new(store) do
+    %__MODULE__{__next__: store}
+  end
+
+  defimpl FileStore do
+    require Logger
+
+    def stat(store, key) do
+      store.__next__
+      |> FileStore.stat(key)
+      |> log("STAT", key: key)
+    end
+
+    def write(store, key, content) do
+      store.__next__
+      |> FileStore.write(key, content)
+      |> log("WRITE", key: key)
+    end
+
+    def read(store, key) do
+      store.__next__
+      |> FileStore.read(key)
+      |> log("READ", key: key)
+    end
+
+    def upload(store, source, key) do
+      store.__next__
+      |> FileStore.upload(source, key)
+      |> log("UPLOAD", key: key)
+    end
+
+    def download(store, key, dest) do
+      store.__next__
+      |> FileStore.download(key, dest)
+      |> log("DOWNLOAD", key: key)
+    end
+
+    def delete(store, key) do
+      store.__next__
+      |> FileStore.delete(key)
+      |> log("DELETE", key: key)
+    end
+
+    def get_public_url(store, key, opts) do
+      FileStore.get_public_url(store.__next__, key, opts)
+    end
+
+    def get_signed_url(store, key, opts) do
+      FileStore.get_signed_url(store.__next__, key, opts)
+    end
+
+    def list!(store, opts) do
+      FileStore.list!(store.__next__, opts)
+    end
+
+    def log(result, msg, meta) do
+      case normalize(result) do
+        :ok ->
+          log_msg(:debug, msg, "OK", meta)
+
+        {:error, extra_meta} ->
+          meta = Keyword.merge(meta, extra_meta)
+          log_msg(:warn, msg, "ERROR", meta)
+      end
+
+      result
+    end
+
+    defp log_msg(level, msg, status, meta) do
+      Logger.log(level, fn -> [msg, ?\s, status, ?\s, inspect_meta(meta)] end)
+    end
+
+    defp normalize(:ok), do: :ok
+    defp normalize({:ok, _}), do: :ok
+    defp normalize(:error), do: {:error, []}
+    defp normalize({:error, reason}), do: {:error, [error: reason]}
+
+    defp inspect_meta(meta) do
+      Enum.map_join(meta, " ", fn {key, value} ->
+        "#{key}=#{inspect(value)}"
+      end)
+    end
+  end
+end

--- a/test/file_store/middleware/logger_test.exs
+++ b/test/file_store/middleware/logger_test.exs
@@ -1,0 +1,36 @@
+defmodule FileStore.Middleware.LoggerTest do
+  use FileStore.AdapterCase
+  import ExUnit.CaptureLog
+  require Logger
+
+  @config [base_url: "http://localhost:4000"]
+
+  setup :silence_logger
+
+  setup do
+    start_supervised!(FileStore.Adapters.Memory)
+    store = FileStore.Adapters.Memory.new(@config)
+    store = FileStore.Middleware.Logger.new(store)
+    {:ok, store: store}
+  end
+
+  test "logs a successful write", %{store: store} do
+    Logger.configure(level: :debug)
+    out = capture_log(fn -> FileStore.write(store, "foo", "bar") end)
+    assert out =~ ~r/WRITE OK key="foo"/
+  end
+
+  test "logs a failed read", %{store: store} do
+    Logger.configure(level: :debug)
+    out = capture_log(fn -> FileStore.read(store, "none") end)
+    assert out =~ ~r/READ ERROR key="none" error=:enoent/
+  end
+
+  defp silence_logger(_) do
+    Logger.configure(level: :error)
+
+    on_exit(fn ->
+      Logger.configure(level: :debug)
+    end)
+  end
+end


### PR DESCRIPTION
Middlewares wrap adapters with additional behavior. For example:

```elixir
config
|> FileStore.Adapters.Disk.new()
|> FileStore.Middleware.Logger.new()
|> FileStore.write("foo", "bar")
[debug] WRITE OK key="foo"
:ok
```