### PR TITLE
Create a prefix middleware

### DIFF
--- a/lib/file_store/middleware/prefix.ex
+++ b/lib/file_store/middleware/prefix.ex
@@ -1,0 +1,73 @@
+defmodule FileStore.Middleware.Prefix do
+  @enforce_keys [:__next__, :prefix]
+  defstruct [:__next__, :prefix]
+
+  @doc "Add the prefix adapter to your store."
+  def new(store, opts) do
+    struct(__MODULE__, Keyword.put(opts, :__next__, store))
+  end
+
+  defimpl FileStore do
+    alias FileStore.Stat
+    alias FileStore.Utils
+
+    def stat(store, key) do
+      with {:ok, stat} <- FileStore.stat(store.__next__, put_prefix(key, store)) do
+        {:ok, %Stat{stat | key: remove_prefix(stat.key, store)}}
+      end
+    end
+
+    def delete(store, key) do
+      FileStore.delete(store.__next__, put_prefix(key, store))
+    end
+
+    def write(store, key, content) do
+      FileStore.write(store.__next__, put_prefix(key, store), content)
+    end
+
+    def read(store, key) do
+      FileStore.read(store.__next__, put_prefix(key, store))
+    end
+
+    def upload(store, source, key) do
+      FileStore.upload(store.__next__, source, put_prefix(key, store))
+    end
+
+    def download(store, key, dest) do
+      FileStore.download(store.__next__, put_prefix(key, store), dest)
+    end
+
+    def get_public_url(store, key, opts) do
+      FileStore.get_public_url(store.__next__, put_prefix(key, store), opts)
+    end
+
+    def get_signed_url(store, key, opts) do
+      FileStore.get_signed_url(store.__next__, put_prefix(key, store), opts)
+    end
+
+    def list!(store, opts) do
+      opts = update_key(opts, :prefix, &put_prefix(&1, store))
+
+      store.__next__
+      |> FileStore.list!(opts)
+      |> Stream.map(&remove_prefix(&1, store))
+    end
+
+    defp put_prefix(key, store) do
+      Utils.join(store.prefix, key)
+    end
+
+    defp remove_prefix(key, store) do
+      key
+      |> String.trim_leading(store.prefix)
+      |> String.trim_leading("/")
+    end
+
+    defp update_key(opts, key, fun) do
+      case Keyword.fetch(opts, key) do
+        {:ok, value} -> Keyword.put(opts, key, fun.(value))
+        :error -> opts
+      end
+    end
+  end
+end

--- a/test/file_store/middleware/prefix_test.exs
+++ b/test/file_store/middleware/prefix_test.exs
@@ -1,0 +1,37 @@
+defmodule FileStore.Middleware.PrefixTest do
+  use FileStore.AdapterCase
+
+  alias FileStore.Adapters.Memory
+  alias FileStore.Middleware.Prefix
+
+  @config [base_url: "http://localhost:4000"]
+  @plain Memory.new(@config)
+
+  setup do
+    start_supervised!(Memory)
+    store = Memory.new(@config)
+    store = Prefix.new(store, prefix: "prefix")
+    {:ok, store: store}
+  end
+
+  test "adds a prefix to keys", %{store: store} do
+    assert :ok = FileStore.write(store, "foo", "prefixed")
+    assert {:ok, "prefixed"} = FileStore.read(@plain, "prefix/foo")
+  end
+
+  test "stat/2 removes prefix from the key", %{store: store} do
+    assert :ok = FileStore.write(store, "foo", "bar")
+
+    assert {:ok, stat} = FileStore.stat(store, "foo")
+    assert stat.key == "foo"
+
+    assert {:ok, stat} = FileStore.stat(@plain, "prefix/foo")
+    assert stat.key == "prefix/foo"
+  end
+
+  test "list!/2 removes prefix from the key", %{store: store} do
+    assert :ok = FileStore.write(store, "foo", "bar")
+    assert "foo" in Enum.to_list(FileStore.list!(store))
+    assert "prefix/foo" in Enum.to_list(FileStore.list!(@plain))
+  end
+end


### PR DESCRIPTION
This middleware will prepend a prefix to the key. This is useful, because it means the S3 adapter doesn't have to worry about the prefix. It also means that prefixing is now compatible with any adapter.

This PR includes a breaking change to the S3 adapter. The `prefix` option is no longer accepted by the S3 adapter.

In previous versions, using the `:prefix` would still return unprefixed keys from the `list!` and `stat` functions. That's no longer the case, which means the result of those functions can be used to interact with the store.
 

