### PR TITLE
Allow `:content_type` and `:disposition` to be set when writing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: priv/plts
-          key: plts-${{ matrix.elixir }}
+          key: plts-otp24-elixir1.13
       - name: Dialyzer
         run: mix dialyzer
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     env:
-      MIX_ENV: test
+      MIX_ENV: dev
     name: Lint
     steps:
       - uses: actions/checkout@v2
@@ -30,8 +30,6 @@ jobs:
           key: plts-otp24-elixir1.13
       - name: Dialyzer
         run: mix dialyzer
-        env:
-          MIX_ENV: dev
       - name: Credo
         run: mix credo --all
   # Build phase to check against multiple versions of OTP and elixir for as

--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -19,6 +19,10 @@ defprotocol FileStore do
   @type key :: binary()
   @type list_opts :: [{:prefix, binary()}]
   @type delete_all_opts :: [{:prefix, binary()}]
+  @type write_opts :: [
+          {:content_type, binary()}
+          | {:disposition, binary()}
+        ]
 
   @type public_url_opts :: [
           {:content_type, binary()}
@@ -35,14 +39,19 @@ defprotocol FileStore do
   Write a file to the store. If a file with the given `key`
   already exists, it will be overwritten.
 
+  ## Options
+
+      * `:content_type` - Sets the content type hint for the adapter.
+      * `:disposition` - Sets the content disposition hint for the adapter.
+
   ## Examples
 
       iex> FileStore.write(store, "foo", "hello world")
       :ok
 
   """
-  @spec write(t, key, binary) :: :ok | {:error, term}
-  def write(store, key, content)
+  @spec write(t, key, binary, write_opts) :: :ok | {:error, term}
+  def write(store, key, content, opts \\ [])
 
   @doc """
   Read the contents of a file in store into memory.

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -72,7 +72,15 @@ defmodule FileStore.Adapters.Disk do
       with path <- Disk.join(store, key),
            {:ok, stat} <- File.stat(path),
            {:ok, etag} <- FileStore.Stat.checksum_file(path) do
-        {:ok, %Stat{key: key, size: stat.size, etag: etag}}
+        {
+          :ok,
+          %Stat{
+            key: key,
+            size: stat.size,
+            etag: etag,
+            type: "application/octet-stream"
+          }
+        }
       end
     end
 

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -96,7 +96,7 @@ defmodule FileStore.Adapters.Disk do
       end
     end
 
-    def write(store, key, content) do
+    def write(store, key, content, _opts \\ []) do
       with {:ok, path} <- expand(store, key) do
         File.write(path, content)
       end

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -89,7 +89,15 @@ defmodule FileStore.Adapters.Memory do
       |> Agent.get(&Map.fetch(&1, key))
       |> case do
         {:ok, data} ->
-          {:ok, %Stat{key: key, size: byte_size(data), etag: Stat.checksum(data)}}
+          {
+            :ok,
+            %Stat{
+              key: key,
+              size: byte_size(data),
+              etag: Stat.checksum(data),
+              type: "application/octet-stream"
+            }
+          }
 
         :error ->
           {:error, :enoent}

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -110,7 +110,7 @@ defmodule FileStore.Adapters.Memory do
       end)
     end
 
-    def write(store, key, content) do
+    def write(store, key, content, _opts \\ []) do
       Agent.update(store.name, &Map.put(&1, key, content))
     end
 

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -33,7 +33,7 @@ defmodule FileStore.Adapters.Null do
     def delete_all(_store, _opts), do: :ok
     def upload(_store, _source, _key), do: :ok
     def download(_store, _key, _destination), do: :ok
-    def write(_store, _key, _content), do: :ok
+    def write(_store, _key, _content, _opts \\ []), do: :ok
     def read(_store, _key), do: {:ok, ""}
     def list!(_store, _opts), do: Stream.into([], [])
   end

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -28,7 +28,19 @@ defmodule FileStore.Adapters.Null do
 
     def get_public_url(_store, key, _opts), do: key
     def get_signed_url(_store, key, _opts), do: {:ok, key}
-    def stat(_store, key), do: {:ok, %Stat{key: key, size: 0, etag: Stat.checksum("")}}
+
+    def stat(_store, key) do
+      {
+        :ok,
+        %Stat{
+          key: key,
+          size: 0,
+          etag: Stat.checksum(""),
+          type: "application/octet-stream"
+        }
+      }
+    end
+
     def delete(_store, _key), do: :ok
     def delete_all(_store, _opts), do: :ok
     def upload(_store, _source, _key), do: :ok

--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -111,9 +111,14 @@ if Code.ensure_loaded?(ExAws.S3) do
         error -> {:error, error}
       end
 
-      def write(store, key, content) do
+      def write(store, key, content, opts \\ []) do
+        opts =
+          opts
+          |> Keyword.take([:content_type, :disposition])
+          |> Utils.rename_key(:disposition, :content_disposition)
+
         store.bucket
-        |> ExAws.S3.put_object(key, content)
+        |> ExAws.S3.put_object(key, content, opts)
         |> acknowledge(store)
       end
 

--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -90,7 +90,8 @@ if Code.ensure_loaded?(ExAws.S3) do
             headers = Enum.into(headers, %{})
             etag = headers |> Map.get("ETag") |> unwrap_etag()
             size = headers |> Map.get("Content-Length") |> to_integer()
-            {:ok, %Stat{key: key, etag: etag, size: size}}
+            type = headers |> Map.get("Content-Type")
+            {:ok, %Stat{key: key, etag: etag, size: size, type: type}}
 
           {:error, reason} ->
             {:error, reason}

--- a/lib/file_store/middleware/errors.ex
+++ b/lib/file_store/middleware/errors.ex
@@ -42,9 +42,9 @@ defmodule FileStore.Middleware.Errors do
       |> wrap(action: "read stats for key", key: key)
     end
 
-    def write(store, key, content) do
+    def write(store, key, content, opts) do
       store.__next__
-      |> FileStore.write(key, content)
+      |> FileStore.write(key, content, opts)
       |> wrap(action: "write to key", key: key)
     end
 

--- a/lib/file_store/middleware/logger.ex
+++ b/lib/file_store/middleware/logger.ex
@@ -21,9 +21,9 @@ defmodule FileStore.Middleware.Logger do
       |> log("STAT", key: key)
     end
 
-    def write(store, key, content) do
+    def write(store, key, content, opts) do
       store.__next__
-      |> FileStore.write(key, content)
+      |> FileStore.write(key, content, opts)
       |> log("WRITE", key: key)
     end
 

--- a/lib/file_store/middleware/prefix.ex
+++ b/lib/file_store/middleware/prefix.ex
@@ -38,8 +38,8 @@ defmodule FileStore.Middleware.Prefix do
       FileStore.delete_all(store.__next__, put_prefix(opts, store))
     end
 
-    def write(store, key, content) do
-      FileStore.write(store.__next__, put_prefix(key, store), content)
+    def write(store, key, content, opts) do
+      FileStore.write(store.__next__, put_prefix(key, store), content, opts)
     end
 
     def read(store, key) do

--- a/lib/file_store/stat.ex
+++ b/lib/file_store/stat.ex
@@ -11,15 +11,18 @@ defmodule FileStore.Stat do
 
     * `size` - The byte size of the file.
 
+    * `type` - The content-type of the file.
+
   """
 
-  @enforce_keys [:key, :size, :etag]
-  defstruct [:key, :size, :etag]
+  @enforce_keys [:key, :size, :etag, :type]
+  defstruct [:key, :size, :etag, :type]
 
   @type t :: %__MODULE__{
           key: binary,
           etag: binary,
-          size: non_neg_integer
+          size: non_neg_integer,
+          type: binary
         }
 
   @doc """

--- a/lib/file_store/utils.ex
+++ b/lib/file_store/utils.ex
@@ -25,4 +25,17 @@ defmodule FileStore.Utils do
 
   def encode_query([]), do: nil
   def encode_query(query), do: URI.encode_query(query)
+
+  @spec rename_key(Keyword.t(), term(), term()) :: Keyword.t()
+  def rename_key(opts, key, new_key) do
+    case Keyword.fetch(opts, key) do
+      {:ok, value} ->
+        opts
+        |> Keyword.delete(key)
+        |> Keyword.put(new_key, value)
+
+      :error ->
+        opts
+    end
+  end
 end

--- a/test/file_store/utils_test.exs
+++ b/test/file_store/utils_test.exs
@@ -45,4 +45,18 @@ defmodule FileStore.UtilsTest do
              |> URI.parse()
              |> Utils.put_query(foo: "bar")
   end
+
+  describe "rename_key/3" do
+    test "renames existing key" do
+      assert [changed: :foo] = Utils.rename_key([target: :foo], :target, :changed)
+    end
+
+    test "returns keywords unchanged when target does not exist" do
+      assert [left: :foo] = Utils.rename_key([left: :foo], :target, :changed)
+    end
+
+    test "returns empty keywords" do
+      assert [] = Utils.rename_key([], :target, :changed)
+    end
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+{:ok, _} = Application.ensure_all_started(:telemetry)
+
 ExUnit.start()


### PR DESCRIPTION
ExAws.S3 allows sending :content_type and :content_disposition when
putting objects into storage. Other options are allowed, but in order to
keep consistent with the current FileStore interface, we are only going
to allow `:content_type` and `:disposition` to be sent.

https://hexdocs.pm/ex_aws_s3/ExAws.S3.html#put_object/4