### PR TITLE
Adds copy and rename ability for adapters to implement

### DIFF
--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -134,6 +134,32 @@ defprotocol FileStore do
   def delete_all(store, opts \\ [])
 
   @doc """
+  Copy a file to a new location.
+
+  ## Examples
+
+      iex> FileStore.copy(store, "path/foo.txt", "path/bar.txt")
+      :ok
+
+  """
+  @spec copy(t(), key(), key()) :: :ok | {:error, term()}
+  def copy(store, src, dest)
+
+  @doc """
+  Renames a file from one name to another.
+
+  **Note**: Some underlying adapters can not do this in an atomic fashion.
+
+  ## Examples
+
+      iex> FileStore.rename(store, "path/foo.txt", "path/bar.txt")
+      :ok
+
+  """
+  @spec rename(t(), key(), key()) :: :ok | {:error, term()}
+  def rename(store, src, dest)
+
+  @doc """
   Get URL for your file, assuming that the file is publicly accessible.
 
   ## Options

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -114,6 +114,19 @@ defmodule FileStore.Adapters.Disk do
       store |> Disk.join(key) |> File.read()
     end
 
+    def copy(store, src, dest) do
+      with {:ok, src} <- expand(store, src),
+           {:ok, dest} <- expand(store, dest),
+           {:ok, _} <- File.copy(src, dest),
+           do: :ok
+    end
+
+    def rename(store, src, dest) do
+      with {:ok, src} <- expand(store, src),
+           {:ok, dest} <- expand(store, dest),
+           do: File.rename(src, dest)
+    end
+
     def upload(store, source, key) do
       with {:ok, dest} <- expand(store, key),
            {:ok, _} <- File.copy(source, dest),

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -130,6 +130,30 @@ defmodule FileStore.Adapters.Memory do
       end)
     end
 
+    def copy(store, src, dest) do
+      Agent.get_and_update(store.name, fn state ->
+        case Map.fetch(state, src) do
+          {:ok, value} ->
+            {:ok, Map.put(state, dest, value)}
+
+          :error ->
+            {{:error, :enoent}, state}
+        end
+      end)
+    end
+
+    def rename(store, src, dest) do
+      Agent.get_and_update(store.name, fn state ->
+        case Map.fetch(state, src) do
+          {:ok, value} ->
+            {:ok, state |> Map.delete(src) |> Map.put(dest, value)}
+
+          :error ->
+            {{:error, :enoent}, state}
+        end
+      end)
+    end
+
     def upload(store, source, key) do
       with {:ok, data} <- File.read(source) do
         write(store, key, data)

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -47,6 +47,8 @@ defmodule FileStore.Adapters.Null do
     def download(_store, _key, _destination), do: :ok
     def write(_store, _key, _content, _opts \\ []), do: :ok
     def read(_store, _key), do: {:ok, ""}
+    def copy(_store, _src, _dest), do: :ok
+    def rename(_store, _src, _dest), do: :ok
     def list!(_store, _opts), do: Stream.into([], [])
   end
 end

--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -157,6 +157,18 @@ if Code.ensure_loaded?(ExAws.S3) do
         |> Stream.map(fn file -> file.key end)
       end
 
+      def copy(store, src, dest) do
+        store.bucket
+        |> ExAws.S3.put_object_copy(dest, store.bucket, src)
+        |> acknowledge(store)
+      end
+
+      def rename(store, src, dest) do
+        with :ok <- copy(store, src, dest) do
+          delete(store, src)
+        end
+      end
+
       defp request(op, store) do
         ExAws.request(op, store.ex_aws)
       end

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -77,9 +77,9 @@ defmodule FileStore.Config do
         FileStore.read(new(), key)
       end
 
-      @spec write(binary(), binary()) :: :ok | {:error, term()}
-      def write(key, content) do
-        FileStore.write(new(), key, content)
+      @spec write(binary(), binary(), FileStore.write_opts()) :: :ok | {:error, term()}
+      def write(key, content, opts \\ []) do
+        FileStore.write(new(), key, content, opts)
       end
 
       @spec delete(binary()) :: :ok | {:error, term()}

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -77,12 +77,12 @@ defmodule FileStore.Config do
         FileStore.read(new(), key)
       end
 
-      @spec write(binary(), binary(), FileStore.write_opts()) :: :ok | {:error, term()}
+      @spec write(FileStore.key(), binary(), FileStore.write_opts()) :: :ok | {:error, term()}
       def write(key, content, opts \\ []) do
         FileStore.write(new(), key, content, opts)
       end
 
-      @spec delete(binary()) :: :ok | {:error, term()}
+      @spec delete(FileStore.key()) :: :ok | {:error, term()}
       def delete(key) do
         FileStore.delete(new(), key)
       end
@@ -107,17 +107,17 @@ defmodule FileStore.Config do
         FileStore.upload(new(), source, key)
       end
 
-      @spec download(binary(), Path.t()) :: :ok | {:error, term()}
+      @spec download(FileStore.key(), Path.t()) :: :ok | {:error, term()}
       def download(key, destination) do
         FileStore.download(new(), key, destination)
       end
 
-      @spec get_public_url(binary(), Keyword.t()) :: binary()
+      @spec get_public_url(FileStore.key(), Keyword.t()) :: binary()
       def get_public_url(key, opts \\ []) do
         FileStore.get_public_url(new(), key, opts)
       end
 
-      @spec get_signed_url(binary(), Keyword.t()) :: {:ok, binary()} | {:error, term()}
+      @spec get_signed_url(FileStore.key(), Keyword.t()) :: {:ok, binary()} | {:error, term()}
       def get_signed_url(key, opts \\ []) do
         FileStore.get_signed_url(new(), key, opts)
       end

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -92,6 +92,16 @@ defmodule FileStore.Config do
         FileStore.delete_all(new(), opts)
       end
 
+      @spec copy(FileStore.key(), FileStore.key()) :: :ok | {:error, term()}
+      def copy(src, dest) do
+        FileStore.copy(new(), src, dest)
+      end
+
+      @spec rename(FileStore.key(), FileStore.key()) :: :ok | {:error, term()}
+      def rename(src, dest) do
+        FileStore.rename(new(), src, dest)
+      end
+
       @spec upload(Path.t(), binary()) :: :ok | {:error, term()}
       def upload(source, key) do
         FileStore.upload(new(), source, key)

--- a/lib/file_store/error.ex
+++ b/lib/file_store/error.ex
@@ -41,3 +41,23 @@ defmodule FileStore.DownloadError do
     "could not download key #{inspect(key)} to file #{inspect(path)}: #{reason}"
   end
 end
+
+defmodule FileStore.CopyError do
+  defexception [:reason, :src, :dest]
+
+  @impl true
+  def message(%{reason: reason, src: src, dest: dest}) do
+    reason = FileStore.Error.format(reason)
+    "could not copy #{inspect(src)} to #{inspect(dest)}: #{reason}"
+  end
+end
+
+defmodule FileStore.RenameError do
+  defexception [:reason, :src, :dest]
+
+  @impl true
+  def message(%{reason: reason, src: src, dest: dest}) do
+    reason = FileStore.Error.format(reason)
+    "could not rename #{inspect(src)} to #{inspect(dest)}: #{reason}"
+  end
+end

--- a/lib/file_store/middleware/errors.ex
+++ b/lib/file_store/middleware/errors.ex
@@ -35,6 +35,8 @@ defmodule FileStore.Middleware.Errors do
     alias FileStore.Error
     alias FileStore.UploadError
     alias FileStore.DownloadError
+    alias FileStore.RenameError
+    alias FileStore.CopyError
 
     def stat(store, key) do
       store.__next__
@@ -52,6 +54,18 @@ defmodule FileStore.Middleware.Errors do
       store.__next__
       |> FileStore.read(key)
       |> wrap(action: "read key", key: key)
+    end
+
+    def copy(store, src, dest) do
+      store.__next__
+      |> FileStore.copy(src, dest)
+      |> wrap(CopyError, action: "copy", src: src, dest: dest)
+    end
+
+    def rename(store, src, dest) do
+      store.__next__
+      |> FileStore.rename(src, dest)
+      |> wrap(RenameError, action: "rename", src: src, dest: dest)
     end
 
     def upload(store, path, key) do

--- a/lib/file_store/middleware/logger.ex
+++ b/lib/file_store/middleware/logger.ex
@@ -33,6 +33,18 @@ defmodule FileStore.Middleware.Logger do
       |> log("READ", key: key)
     end
 
+    def copy(store, src, dest) do
+      store.__next__
+      |> FileStore.copy(src, dest)
+      |> log("COPY", src: src, dest: dest)
+    end
+
+    def rename(store, src, dest) do
+      store.__next__
+      |> FileStore.rename(src, dest)
+      |> log("RENAME", src: src, dest: dest)
+    end
+
     def upload(store, source, key) do
       store.__next__
       |> FileStore.upload(source, key)

--- a/lib/file_store/middleware/prefix.ex
+++ b/lib/file_store/middleware/prefix.ex
@@ -46,6 +46,14 @@ defmodule FileStore.Middleware.Prefix do
       FileStore.read(store.__next__, put_prefix(key, store))
     end
 
+    def copy(store, src, dest) do
+      FileStore.copy(store.__next__, put_prefix(src, store), put_prefix(dest, store))
+    end
+
+    def rename(store, src, dest) do
+      FileStore.rename(store.__next__, put_prefix(src, store), put_prefix(dest, store))
+    end
+
     def upload(store, source, key) do
       FileStore.upload(store.__next__, source, put_prefix(key, store))
     end

--- a/test/file_store/adapters/disk_test.exs
+++ b/test/file_store/adapters/disk_test.exs
@@ -24,4 +24,48 @@ defmodule FileStore.Adapters.DiskTest do
     assert get_query(url, "content_type") == "text/plain"
     assert get_query(url, "disposition") == "attachment"
   end
+
+  describe "copy/3" do
+    test "copies a file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+
+      assert :ok = FileStore.copy(store, "foo", "bar")
+      assert {:ok, "test"} = FileStore.read(store, "foo")
+    end
+
+    test "fails to copy a non existing file", %{store: store} do
+      assert {:error, :enoent} = FileStore.copy(store, "doesnotexist.txt", "shouldnotexist.txt")
+    end
+
+    test "copy replaces existing file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+      :ok = FileStore.write(store, "bar", "i exist")
+
+      assert :ok = FileStore.copy(store, "foo", "bar")
+      assert {:ok, "test"} = FileStore.read(store, "bar")
+    end
+  end
+
+  describe "rename/3" do
+    test "renames a file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+
+      assert :ok = FileStore.rename(store, "foo", "bar")
+      assert {:error, _} = FileStore.stat(store, "foo")
+      assert {:ok, _} = FileStore.stat(store, "bar")
+    end
+
+    test "fails to rename a non existing file", %{store: store} do
+      assert {:error, :enoent} = FileStore.rename(store, "doesnotexist.txt", "shouldnotexist.txt")
+    end
+
+    test "rename replaces existing file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+      :ok = FileStore.write(store, "bar", "i exist")
+
+      assert :ok = FileStore.rename(store, "foo", "bar")
+      assert {:error, _} = FileStore.stat(store, "foo")
+      assert {:ok, _} = FileStore.stat(store, "bar")
+    end
+  end
 end

--- a/test/file_store/adapters/memory_test.exs
+++ b/test/file_store/adapters/memory_test.exs
@@ -25,4 +25,48 @@ defmodule FileStore.Adapters.MemoryTest do
     assert get_query(url, "content_type") == "text/plain"
     assert get_query(url, "disposition") == "attachment"
   end
+
+  describe "copy/3" do
+    test "copies a file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+
+      assert :ok = FileStore.copy(store, "foo", "bar")
+      assert {:ok, "test"} = FileStore.read(store, "foo")
+    end
+
+    test "fails to copy a non existing file", %{store: store} do
+      assert {:error, :enoent} = FileStore.copy(store, "doesnotexist.txt", "shouldnotexist.txt")
+    end
+
+    test "copy replaces existing file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+      :ok = FileStore.write(store, "bar", "i exist")
+
+      assert :ok = FileStore.copy(store, "foo", "bar")
+      assert {:ok, "test"} = FileStore.read(store, "bar")
+    end
+  end
+
+  describe "rename/3" do
+    test "renames a file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+
+      assert :ok = FileStore.rename(store, "foo", "bar")
+      assert {:error, _} = FileStore.stat(store, "foo")
+      assert {:ok, _} = FileStore.stat(store, "bar")
+    end
+
+    test "fails to rename a non existing file", %{store: store} do
+      assert {:error, :enoent} = FileStore.rename(store, "doesnotexist.txt", "shouldnotexist.txt")
+    end
+
+    test "rename replaces existing file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+      :ok = FileStore.write(store, "bar", "i exist")
+
+      assert :ok = FileStore.rename(store, "foo", "bar")
+      assert {:error, _} = FileStore.stat(store, "foo")
+      assert {:ok, _} = FileStore.stat(store, "bar")
+    end
+  end
 end

--- a/test/file_store/adapters/null_test.exs
+++ b/test/file_store/adapters/null_test.exs
@@ -43,4 +43,26 @@ defmodule FileStore.Adapters.NullTest do
   test "list/0", %{store: store} do
     assert Enum.to_list(FileStore.list!(store)) == []
   end
+
+  describe "copy/3" do
+    test "copies a file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+      assert :ok = FileStore.copy(store, "foo", "bar")
+    end
+
+    test "copies a non existing file", %{store: store} do
+      assert :ok = FileStore.copy(store, "doesnotexist.txt", "shouldnotexist.txt")
+    end
+  end
+
+  describe "rename/3" do
+    test "renames a file", %{store: store} do
+      :ok = FileStore.write(store, "foo", "test")
+      assert :ok = FileStore.rename(store, "foo", "bar")
+    end
+
+    test "renames non existing file", %{store: store} do
+      assert :ok = FileStore.rename(store, "doesnotexist.txt", "shouldnotexist.txt")
+    end
+  end
 end


### PR DESCRIPTION
* Adds `FileStore.copy/3`.
* Adds `FileStore.rename/3`.
* Adds `FileStore.CopyError`
* Adds `FileStore.RenameError`
* Fixes missing options for write when using `FileStore.Config`.
* Improves typespecs for `FileStore.Config` compile time generated functions.