### PR TITLE
Adds `stream!/3` interface

### DIFF
--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -16,24 +16,33 @@ defprotocol FileStore do
   it's usage.
   """
 
+  @typedoc "The file key."
   @type key :: binary()
-  @type list_opts :: [{:prefix, binary()}]
-  @type delete_all_opts :: [{:prefix, binary()}]
-  @type write_opts :: [
-          {:content_type, binary()}
-          | {:disposition, binary()}
-        ]
 
-  @type public_url_opts :: [
-          {:content_type, binary()}
-          | {:disposition, binary()}
-        ]
+  @typedoc "The prefix path option."
+  @type prefix_opt :: {:prefix, binary()}
 
-  @type signed_url_opts :: [
-          {:content_type, binary()}
-          | {:disposition, binary()}
-          | {:expires_in, integer()}
-        ]
+  @typedoc "The file content disposition hint for the adapter."
+  @type disposition_opt :: {:disposition, binary()}
+
+  @typedoc "The file content type hint for the adapter."
+  @type content_type_opt :: {:content_type, binary()}
+
+  @typedoc "The number of seconds the URL will expire in."
+  @type expires_in_opt :: {:expires_in, integer()}
+
+  @typedoc "The number of bytes to chunk a stream with."
+  @type chunk_size_opt :: {:chunk_size, pos_integer()}
+
+  @typedoc "Streams a file line by line."
+  @type line_opt :: {:line, boolean()}
+
+  @type list_opts :: [prefix_opt()]
+  @type delete_all_opts :: [prefix_opt()]
+  @type write_opts :: [content_type_opt() | disposition_opt()]
+  @type public_url_opts :: [content_type_opt() | disposition_opt()]
+  @type signed_url_opts :: [content_type_opt() | disposition_opt() | expires_in_opt()]
+  @type stream_opts :: [chunk_size_opt() | line_opt()]
 
   @doc """
   Write a file to the store. If a file with the given `key`
@@ -64,6 +73,19 @@ defprotocol FileStore do
   """
   @spec read(t, key) :: {:ok, binary} | {:error, term}
   def read(store, key)
+
+  @doc """
+  Stream the file from from the store.
+
+  ## Options
+
+  * `:chunk_size` - The number of bytes for each chunk of data. It can not be
+    specified with `:line`.
+  * `:line` - Streams the file line by line. It can not be specified with
+    `:chunk_size`.
+  """
+  @spec stream!(t, key, stream_opts) :: Enumerable.t()
+  def stream!(store, key, opts \\ [])
 
   @doc """
   Upload a file to the store. If a file with the given `key`

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -114,6 +114,17 @@ defmodule FileStore.Adapters.Disk do
       store |> Disk.join(key) |> File.read()
     end
 
+    def stream!(store, key, opts \\ []) do
+      path = Disk.join(store, key)
+
+      if opts[:line] do
+        File.stream!(path, :line)
+      else
+        chunk_size = opts[:chunk_size] || 2048
+        File.stream!(path, chunk_size)
+      end
+    end
+
     def copy(store, src, dest) do
       with {:ok, src} <- expand(store, src),
            {:ok, dest} <- expand(store, dest),

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -47,6 +47,7 @@ defmodule FileStore.Adapters.Null do
     def download(_store, _key, _destination), do: :ok
     def write(_store, _key, _content, _opts \\ []), do: :ok
     def read(_store, _key), do: {:ok, ""}
+    def stream!(_store, _key, _opts \\ []), do: Stream.into([], [])
     def copy(_store, _src, _dest), do: :ok
     def rename(_store, _src, _dest), do: :ok
     def list!(_store, _opts), do: Stream.into([], [])

--- a/lib/file_store/middleware/errors.ex
+++ b/lib/file_store/middleware/errors.ex
@@ -58,6 +58,10 @@ defmodule FileStore.Middleware.Errors do
       |> wrap(action: "read key", key: key)
     end
 
+    def stream!(store, key, opts) do
+      FileStore.stream!(store.__next__, key, opts)
+    end
+
     def copy(store, src, dest) do
       store.__next__
       |> FileStore.copy(src, dest)

--- a/lib/file_store/middleware/logger.ex
+++ b/lib/file_store/middleware/logger.ex
@@ -33,6 +33,12 @@ defmodule FileStore.Middleware.Logger do
       |> log("READ", key: key)
     end
 
+    def stream!(store, key, opts) do
+      store.__next__
+      |> FileStore.stream!(key, opts)
+      |> log!("STREAM", key: key)
+    end
+
     def copy(store, src, dest) do
       store.__next__
       |> FileStore.copy(src, dest)
@@ -100,6 +106,11 @@ defmodule FileStore.Middleware.Logger do
       end)
 
       {:error, error}
+    end
+
+    defp log!(io, msg, meta) do
+      log(:ok, msg, meta)
+      io
     end
 
     defp format_meta(meta) do

--- a/lib/file_store/middleware/prefix.ex
+++ b/lib/file_store/middleware/prefix.ex
@@ -46,6 +46,10 @@ defmodule FileStore.Middleware.Prefix do
       FileStore.read(store.__next__, put_prefix(key, store))
     end
 
+    def stream!(store, key, opts) do
+      FileStore.stream!(store.__next__, put_prefix(key, store), opts)
+    end
+
     def copy(store, src, dest) do
       FileStore.copy(store.__next__, put_prefix(src, store), put_prefix(dest, store))
     end

--- a/test/support/error_adapter.ex
+++ b/test/support/error_adapter.ex
@@ -10,6 +10,11 @@ defmodule FileStore.Adapters.Error do
   defimpl FileStore do
     def write(_store, _key, _content, _opts \\ []), do: {:error, :boom}
     def read(_store, _key), do: {:error, :boom}
+
+    def stream!(_store, key, _opts \\ []) do
+      raise FileStore.Error, reason: "Does not work", key: key, action: "stream"
+    end
+
     def upload(_store, _source, _key), do: {:error, :boom}
     def download(_store, _key, _destination), do: {:error, :boom}
     def stat(_store, _key), do: {:error, :boom}


### PR DESCRIPTION
This is a rough draft of what I think the stream implementation should be like. I do not know how I am going to test the error case where the file can not be found with any of the adapters. The exception happens in a supervised storage implementation that is inside of a macro for the adapter cases.

I'm looking for some feedback on this while I work through this.

Closes #33