### PR TITLE
Add `opts` to `upload`

### DIFF
--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -16,23 +16,34 @@ defprotocol FileStore do
   it's usage.
   """
 
-  @type key :: binary()
-  @type list_opts :: [{:prefix, binary()}]
-  @type delete_all_opts :: [{:prefix, binary()}]
+  @type key :: String.t()
+
+  @type prefix_opt :: {:prefix, String.t()}
+  @type content_type_opt :: {:content_type, String.t()}
+  @type disposition_opt :: {:disposition, String.t()}
+  @type expires_in_opt :: {:expires_in, pos_integer()}
+
+  @type list_opts :: [prefix_opt()]
+  @type delete_all_opts :: [prefix_opt()]
   @type write_opts :: [
-          {:content_type, binary()}
-          | {:disposition, binary()}
+          content_type_opt()
+          | disposition_opt()
+        ]
+
+  @type upload_opts :: [
+          content_type_opt()
+          | disposition_opt()
         ]
 
   @type public_url_opts :: [
-          {:content_type, binary()}
-          | {:disposition, binary()}
+          content_type_opt()
+          | disposition_opt()
         ]
 
   @type signed_url_opts :: [
-          {:content_type, binary()}
-          | {:disposition, binary()}
-          | {:expires_in, integer()}
+          content_type_opt()
+          | disposition_opt()
+          | expires_in_opt()
         ]
 
   @doc """
@@ -50,7 +61,12 @@ defprotocol FileStore do
       :ok
 
   """
-  @spec write(t, key, binary, write_opts) :: :ok | {:error, term}
+  @spec write(
+          store :: t(),
+          key :: key(),
+          content :: binary(),
+          opts :: write_opts()
+        ) :: :ok | {:error, term()}
   def write(store, key, content, opts \\ [])
 
   @doc """
@@ -62,7 +78,7 @@ defprotocol FileStore do
       {:ok, "hello world"}
 
   """
-  @spec read(t, key) :: {:ok, binary} | {:error, term}
+  @spec read(store :: t(), key :: key()) :: {:ok, binary()} | {:error, term()}
   def read(store, key)
 
   @doc """
@@ -75,8 +91,13 @@ defprotocol FileStore do
       :ok
 
   """
-  @spec upload(t, Path.t(), key) :: :ok | {:error, term}
-  def upload(store, source, key)
+  @spec upload(
+          store :: t(),
+          source :: Path.t(),
+          key :: key(),
+          opts :: upload_opts()
+        ) :: :ok | {:error, term()}
+  def upload(store, source, key, opts \\ [])
 
   @doc """
   Download a file from the store and save it to the given `path`.
@@ -87,7 +108,11 @@ defprotocol FileStore do
       :ok
 
   """
-  @spec download(t, key, Path.t()) :: :ok | {:error, term}
+  @spec download(
+          store :: t(),
+          key :: key(),
+          destination :: Path.t()
+        ) :: :ok | {:error, term()}
   def download(store, key, destination)
 
   @doc """
@@ -99,7 +124,7 @@ defprotocol FileStore do
       {:ok, %FileStore.Stat{key: "foo", etag: "2e5pd429", size: 24}}
 
   """
-  @spec stat(t, key) :: {:ok, FileStore.Stat.t()} | {:error, term}
+  @spec stat(store :: t(), key :: key()) :: {:ok, FileStore.Stat.t()} | {:error, term()}
   def stat(store, key)
 
   @doc """
@@ -111,7 +136,7 @@ defprotocol FileStore do
     :ok
 
   """
-  @spec delete(t, key) :: :ok | {:error, term}
+  @spec delete(store :: t(), key :: key()) :: :ok | {:error, term()}
   def delete(store, key)
 
   @doc """
@@ -130,7 +155,7 @@ defprotocol FileStore do
     :ok
 
   """
-  @spec delete_all(t, delete_all_opts) :: :ok | {:error, term}
+  @spec delete_all(store :: t(), opts :: delete_all_opts()) :: :ok | {:error, term()}
   def delete_all(store, opts \\ [])
 
   @doc """
@@ -142,7 +167,7 @@ defprotocol FileStore do
       :ok
 
   """
-  @spec copy(t(), key(), key()) :: :ok | {:error, term()}
+  @spec copy(store :: t(), src :: key(), dest :: key()) :: :ok | {:error, term()}
   def copy(store, src, dest)
 
   @doc """
@@ -156,7 +181,7 @@ defprotocol FileStore do
       :ok
 
   """
-  @spec rename(t(), key(), key()) :: :ok | {:error, term()}
+  @spec rename(strore :: t(), src :: key(), dest :: key()) :: :ok | {:error, term()}
   def rename(store, src, dest)
 
   @doc """
@@ -173,7 +198,7 @@ defprotocol FileStore do
       "https://mybucket.s3-us-east-1.amazonaws.com/foo"
 
   """
-  @spec get_public_url(t, key, public_url_opts) :: binary
+  @spec get_public_url(strore :: t(), key :: key(), opts :: public_url_opts()) :: String.t()
   def get_public_url(store, key, opts \\ [])
 
   @doc """
@@ -192,7 +217,11 @@ defprotocol FileStore do
       {:ok, "https://s3.amazonaws.com/mybucket/foo?X-AMZ-Expires=3600&..."}
 
   """
-  @spec get_signed_url(t, key, signed_url_opts) :: {:ok, binary} | {:error, term}
+  @spec get_signed_url(
+          store :: t(),
+          key :: key(),
+          opts :: signed_url_opts()
+        ) :: {:ok, binary()} | {:error, term()}
   def get_signed_url(store, key, opts \\ [])
 
   @doc """
@@ -211,6 +240,6 @@ defprotocol FileStore do
       ["foo/bar"]
 
   """
-  @spec list!(t, list_opts) :: Enumerable.t()
+  @spec list!(store :: t(), opts :: list_opts()) :: Enumerable.t()
   def list!(store, opts \\ [])
 end

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -127,7 +127,7 @@ defmodule FileStore.Adapters.Disk do
            do: File.rename(src, dest)
     end
 
-    def upload(store, source, key) do
+    def upload(store, source, key, _opts \\ []) do
       with {:ok, dest} <- expand(store, key),
            {:ok, _} <- File.copy(source, dest),
            do: :ok

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -154,7 +154,7 @@ defmodule FileStore.Adapters.Memory do
       end)
     end
 
-    def upload(store, source, key) do
+    def upload(store, source, key, _opts \\ []) do
       with {:ok, data} <- File.read(source) do
         write(store, key, data)
       end

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -43,7 +43,7 @@ defmodule FileStore.Adapters.Null do
 
     def delete(_store, _key), do: :ok
     def delete_all(_store, _opts), do: :ok
-    def upload(_store, _source, _key), do: :ok
+    def upload(_store, _source, _key, _opts \\ []), do: :ok
     def download(_store, _key, _destination), do: :ok
     def write(_store, _key, _content, _opts \\ []), do: :ok
     def read(_store, _key), do: {:ok, ""}

--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -133,10 +133,15 @@ if Code.ensure_loaded?(ExAws.S3) do
         end
       end
 
-      def upload(store, source, key) do
+      def upload(store, source, key, opts \\ []) do
+        opts =
+          opts
+          |> Keyword.take([:content_type, :disposition])
+          |> Utils.rename_key(:disposition, :content_disposition)
+
         source
         |> ExAws.S3.Upload.stream_file()
-        |> ExAws.S3.upload(store.bucket, key)
+        |> ExAws.S3.upload(store.bucket, key, opts)
         |> acknowledge(store)
       rescue
         error in [File.Error] -> {:error, error.reason}

--- a/lib/file_store/middleware/errors.ex
+++ b/lib/file_store/middleware/errors.ex
@@ -70,9 +70,9 @@ defmodule FileStore.Middleware.Errors do
       |> wrap(RenameError, src: src, dest: dest)
     end
 
-    def upload(store, path, key) do
+    def upload(store, path, key, opts) do
       store.__next__
-      |> FileStore.upload(path, key)
+      |> FileStore.upload(path, key, opts)
       |> wrap(UploadError, path: path, key: key)
     end
 

--- a/lib/file_store/middleware/logger.ex
+++ b/lib/file_store/middleware/logger.ex
@@ -45,9 +45,9 @@ defmodule FileStore.Middleware.Logger do
       |> log("RENAME", src: src, dest: dest)
     end
 
-    def upload(store, source, key) do
+    def upload(store, source, key, opts) do
       store.__next__
-      |> FileStore.upload(source, key)
+      |> FileStore.upload(source, key, opts)
       |> log("UPLOAD", key: key)
     end
 

--- a/lib/file_store/middleware/prefix.ex
+++ b/lib/file_store/middleware/prefix.ex
@@ -54,8 +54,8 @@ defmodule FileStore.Middleware.Prefix do
       FileStore.rename(store.__next__, put_prefix(src, store), put_prefix(dest, store))
     end
 
-    def upload(store, source, key) do
-      FileStore.upload(store.__next__, source, put_prefix(key, store))
+    def upload(store, source, key, opts) do
+      FileStore.upload(store.__next__, source, put_prefix(key, store), opts)
     end
 
     def download(store, key, dest) do

--- a/test/support/error_adapter.ex
+++ b/test/support/error_adapter.ex
@@ -10,7 +10,7 @@ defmodule FileStore.Adapters.Error do
   defimpl FileStore do
     def write(_store, _key, _content, _opts \\ []), do: {:error, :boom}
     def read(_store, _key), do: {:error, :boom}
-    def upload(_store, _source, _key), do: {:error, :boom}
+    def upload(_store, _source, _key, _opts \\ []), do: {:error, :boom}
     def download(_store, _key, _destination), do: {:error, :boom}
     def stat(_store, _key), do: {:error, :boom}
     def delete(_store, _key), do: {:error, :boom}


### PR DESCRIPTION
I've found the need to pass along the content type and disposition to Amazon in order to have the correct metadata set on the object. I did not want to load the entire binary into memory to call `write`. Instead, I would like to stream the file from disk.

This also expands the typespecs defined. I've opted for `String.t()` in places where I feel the developer should know that it is intended to be a human readable value. Even though under the hood `binary()` and `String.t()` are the same thing, it's still a good signal to the reader.

I realize this will conflict with #34, but I am going to rework that one a bit.