### PR TITLE
Updates to the latest version of elixir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ jobs:
       MIX_ENV: dev
     strategy:
       matrix:
-        os: ["ubuntu-20.04"]
-        elixir: ["1.16"]
-        otp: ["26"]
+        os: ["ubuntu-latest"]
+        elixir: ["1.18"]
+        otp: ["27"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -61,9 +61,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04"]
-        elixir: ["1.16", "1.15", "1.14"]
-        otp: ["26", "25", "24"]
+        os: ["ubuntu-latest"]
+        elixir: ["1.18", "1.17", "1.16", "1.15"]
+        otp: ["27", "26", "25"]
+        exclude:
+          - elixir: "1.15"
+            otp: "27"
+          - elixir: "1.16"
+            otp: "27"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         otp: ["27"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Elixir
         uses: erlef/setup-beam@v1
@@ -23,7 +23,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: deps
           key: ${{ matrix.os }}-otp_${{ matrix.otp }}-elixir_${{ matrix.elixir }}-mix_${{ hashFiles('**/mix.lock') }}
@@ -39,7 +39,7 @@ jobs:
         run: mix deps.unlock --check-unused
 
       - name: Cache dialyzer
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: priv/plts
           key: plts-otp_${{ matrix.otp }}-elixir_${{ matrix.elixir }}
@@ -71,7 +71,7 @@ jobs:
             otp: "27"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Start services
         run: docker compose up -d --wait
@@ -83,7 +83,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: deps
           key: ${{ matrix.os }}-otp_${{ matrix.otp }}-elixir_${{ matrix.elixir }}-mix_${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "24"
-          elixir-version: "1.13"
+          otp-version: "27"
+          elixir-version: "1.18"
 
       - name: Dependencies
         run: mix deps.get

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule FileStore.MixProject do
     [
       app: :file_store,
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
* Drops Elixir 1.14 support.
* Drops OTP 24 support.
* Adds OTP 27 support
* Adds Elixir 1.17 support.
* Adds Elixir 1.18 support.